### PR TITLE
first proposal

### DIFF
--- a/lmf-paradigm-pattern.js
+++ b/lmf-paradigm-pattern.js
@@ -1,0 +1,57 @@
+// #### JSON-structure for the LMF Morphological Patterns package
+// 
+// The following should emulate a parsed pfile into LMF and further
+// transformed and condensed into JSON.
+//
+// The reason why this is so verbose is because it is intended to specify the
+// building of many kinds of morphological technology.
+//
+// The data reflects this:
+// 1+e::msd=sg indef nom#1+es::msd=sg indef gen	0=sopsäckshållare..nn.1,,1=sopsäckshållar#0=solvärmefångare..nn.1,,1=solvärmefångar#0=socialmedicinare..nn.1,,1=socialmedicinar
+//
+// 
+{
+  "MorphologicalPatternID": "id-string", // or a list of IDs?
+  "VariableInstances": [ // this information could be moved under 'Affix'-information in LMF standard, but that seems too far fetched
+    {0: "sopsäckshållare..nn.1", 1: "sopsäckshållar"}, // use 'id' instead of 0?
+    {0: "solvärmefångare..nn.1" ,1: "solvärmefångar"},
+    {0: "socialmedicinare..nn.1", 1: "socialmedicinar"}
+  ],
+  "TransformSet": [
+    {"Process": [
+       {
+	 "operator": "addAfter", // this should be standard 'addAfter' for concatenating
+	 "processType": "pextractAddVariable", // this is pextract specific, rename?
+	 "variableNum": "1" // could be 'stringValue', but now matches use of integers in VariableInstances
+       },
+       {
+	 "operator": "addAfter",
+	 "processType": "pextractAddConstant",
+	 "stringValue": "e"
+       }
+     ],
+     "GrammaticalFeatures": [
+       {"msd": "sg indef nom"}
+     ],
+     "TransformCategory": {},
+     "feat": [{}] // just in case?
+    },
+    {
+      "Process": [
+	{
+	  "operator": "addAfter",
+	  "processType": "pextractAddVariable",
+	  "variableNum": "1"
+	},
+	{
+	  "operator": "addAfter",
+	  "processType": "pextractAddConstant",
+	  "variableNum": "es"
+	}
+      ],
+      "GrammaticalFeatures": [
+	{"msd": "sg indef gen"}
+      ]
+    }
+  ]
+}

--- a/lmf-paradigm-pattern.md
+++ b/lmf-paradigm-pattern.md
@@ -13,17 +13,17 @@ The data (should) reflects this:
 ```javascript
 {
   "MorphologicalPatternID": "id-string", // or a list of IDs?
-  "VariableInstances": [ // this information could be moved under 'Affix'-information in LMF standard, but that seems too far fetched
-    {0: "sopsäckshållare..nn.1", 1: "sopsäckshållar"}, // use 'id' instead of 0?
-    {0: "solvärmefångare..nn.1" ,1: "solvärmefångar"},
-    {0: "socialmedicinare..nn.1", 1: "socialmedicinar"}
+  "VariableInstances": [
+    {"first-attest": "sopsäckshållare..nn.1", "1": "sopsäckshållar"},
+    {"first-attest": "solvärmefångare..nn.1" ,"1": "solvärmefångar"},
+    {"first-attest": "socialmedicinare..nn.1", "1": "socialmedicinar"}
   ],
   "TransformSet": [
     {"Process": [
        {
 	 "operator": "addAfter", // this should be standard 'addAfter' for concatenating
-	 "processType": "pextractAddVariable", // this is pextract specific, rename?
-	 "variableNum": "1" // could be 'stringValue', but now matches use of integers in VariableInstances
+	 "processType": "pextractAddVariable", // this is pextract specific, but need not be prefixed with 'pextract', rename?
+	 "variableNum": "1" 
        },
        {
 	 "operator": "addAfter",
@@ -31,11 +31,11 @@ The data (should) reflects this:
 	 "stringValue": "e"
        }
      ],
-     "GrammaticalFeatures": [
-       {"msd": "sg indef nom"}
-     ],
-     "TransformCategory": {},
-     "feat": [{}] // just in case?
+     "GrammaticalFeatures": {
+         "msd": "sg indef nom"
+       },
+     "TransformCategory": [{}], // this is for higher-order categories like conjugation classes, stem groups etc -- made it a list
+     "feat": [{}] // placeholder just in case
     },
     {
       "Process": [
@@ -47,12 +47,15 @@ The data (should) reflects this:
 	{
 	  "operator": "addAfter",
 	  "processType": "pextractAddConstant",
-	  "variableNum": "es"
+	  "stringValue": "es"
 	}
       ],
-      "GrammaticalFeatures": [
-	{"msd": "sg indef gen"}
-      ]
+      "GrammaticalFeatures":
+	{
+	  "msd": "sg indef gen"
+	},
+      "TransformCategory": [{}],
+      "feat": [{}]
     }
   ]
 }

--- a/lmf-paradigm-pattern.md
+++ b/lmf-paradigm-pattern.md
@@ -1,15 +1,15 @@
-// #### JSON-structure for the LMF Morphological Patterns package
-// 
-// The following should emulate a parsed pfile into LMF and further
-// transformed and condensed into JSON.
-//
-// The reason why this is so verbose is because it is intended to specify the
-// building of many kinds of morphological technology.
-//
-// The data reflects this:
-// 1+e::msd=sg indef nom#1+es::msd=sg indef gen	0=sopsäckshållare..nn.1,,1=sopsäckshållar#0=solvärmefångare..nn.1,,1=solvärmefångar#0=socialmedicinare..nn.1,,1=socialmedicinar
-//
-// 
+# JSON-structure for the LMF Morphological Patterns package
+
+The following should emulate a parsed pfile into LMF and further
+transformed and condensed into JSON.
+
+The reason why this is so verbose is because it is intended to specify the
+building of many kinds of morphological technology.
+
+The data (should) reflects this:
+1+e::msd=sg indef nom#1+es::msd=sg indef gen	0=sopsäckshållare..nn.1,,1=sopsäckshållar#0=solvärmefångare..nn.1,,1=solvärmefångar#0=socialmedicinare..nn.1,,1=socialmedicinar
+
+```javascript
 {
   "MorphologicalPatternID": "id-string", // or a list of IDs?
   "VariableInstances": [ // this information could be moved under 'Affix'-information in LMF standard, but that seems too far fetched
@@ -55,3 +55,4 @@
     }
   ]
 }
+```

--- a/lmf-paradigm-pattern.md
+++ b/lmf-paradigm-pattern.md
@@ -18,6 +18,7 @@ The data (should) reflects this:
     {"first-attest": "solvärmefångare..nn.1" ,"1": "solvärmefångar"},
     {"first-attest": "socialmedicinare..nn.1", "1": "socialmedicinar"}
   ],
+  "TransformCategory": [{}], // this is for higher-order categories like conjugation classes, stem groups etc -- made it a list
   "TransformSet": [
     {"Process": [
        {

--- a/lmf-paradigm-pattern.md
+++ b/lmf-paradigm-pattern.md
@@ -7,7 +7,8 @@ The reason why this is so verbose is because it is intended to specify the
 building of many kinds of morphological technology.
 
 The data (should) reflects this:
-1+e::msd=sg indef nom#1+es::msd=sg indef gen	0=sopsäckshållare..nn.1,,1=sopsäckshållar#0=solvärmefångare..nn.1,,1=solvärmefångar#0=socialmedicinare..nn.1,,1=socialmedicinar
+
+`1+e::msd=sg indef nom#1+es::msd=sg indef gen	0=sopsäckshållare..nn.1,,1=sopsäckshållar#0=solvärmefångare..nn.1,,1=solvärmefångar#0=socialmedicinare..nn.1,,1=socialmedicinar`
 
 ```javascript
 {

--- a/lmf-paradigm-pattern.md
+++ b/lmf-paradigm-pattern.md
@@ -18,7 +18,10 @@ The data (should) reflects this:
     {"first-attest": "solvärmefångare..nn.1" ,"1": "solvärmefångar"},
     {"first-attest": "socialmedicinare..nn.1", "1": "socialmedicinar"}
   ],
-  "TransformCategory": [{}], // this is for higher-order categories like conjugation classes, stem groups etc -- made it a list
+  "TransformCategory": [ // paradigm specific categories
+    {"name": "fm_paradigm", "classes": ["p_apa", "p_bepa"]},
+    {"name": "deklination", "classes": ["1", "8"]}
+  ],
   "TransformSet": [
     {"Process": [
        {
@@ -35,7 +38,7 @@ The data (should) reflects this:
      "GrammaticalFeatures": {
          "msd": "sg indef nom"
        },
-     "TransformCategory": [{}], // this is for higher-order categories like conjugation classes, stem groups etc -- made it a list
+     "TransformCategory": [{}], // wordform specific categories
      "feat": [{}] // placeholder just in case
     },
     {


### PR DESCRIPTION
Here's my first proposal on a json structure for representing the LMF Morphological Paradigm module. It is verbose, but the point is that it should work also for other oracles than pextract. It is meant to be held in Karp as 

Please comment on:
* issues of over-verbosity (where do you want simpler representations?)
* LMF permits it, but is it feasible to hold prediction information and variable constraints here?
* structural compliancy with Karp (and ElasticSearch)